### PR TITLE
Specify 16 to coresMin for per-sample.cwl, and set number of threads

### DIFF
--- a/per-sample/Workflows/per-sample.cwl
+++ b/per-sample/Workflows/per-sample.cwl
@@ -18,7 +18,7 @@ requirements:
     outdirMin: 40960
     ramMin: 48000
     tmpdirMin: 65536
-    coresMin: $(inputs.cores)
+    coresMin: 16
 
 inputs:
   reference:

--- a/per-sample/Workflows/per-sample.cwl
+++ b/per-sample/Workflows/per-sample.cwl
@@ -18,7 +18,7 @@ requirements:
     outdirMin: 40960
     ramMin: 48000
     tmpdirMin: 65536
-    coresMin: $(inputs.coresMin)
+    coresMin: $(inputs.cores)
 
 inputs:
   reference:
@@ -34,9 +34,9 @@ inputs:
       - .alt
       - .fai
       - ^.dict
-  coresMin:
+  cores:
     type: int
-    doc: coresMin
+    doc: nubmer of cores
   bwa_bases_per_batch:
     type: int
     doc: bases in each batch
@@ -148,7 +148,7 @@ steps:
     run: ../Tools/fastqPE2bam.cwl
     in:
       reference: reference
-      bwa_num_threads: coresMin
+      bwa_num_threads: cores
       bwa_bases_per_batch: bwa_bases_per_batch
       sortsam_java_options: sortsam_java_options
       sortsam_max_records_in_ram: sortsam_max_records_in_ram
@@ -178,7 +178,7 @@ steps:
     run: ../Tools/fastqSE2bam.cwl
     in:
       reference: reference
-      bwa_num_threads: coresMin
+      bwa_num_threads: cores
       bwa_bases_per_batch: bwa_bases_per_batch
       sortsam_java_options: sortsam_java_options
       sortsam_max_records_in_ram: sortsam_max_records_in_ram
@@ -219,7 +219,7 @@ steps:
       gatk4_BaseRecalibrator_java_options: gatk4_BaseRecalibrator_java_options
       gatk4_ApplyBQSR_java_options: gatk4_ApplyBQSR_java_options
       static_quantized_quals: static_quantized_quals
-      samtools_num_threads: coresMin
+      samtools_num_threads: cores
     out:
       - markdup_metrics
       - markdup_log
@@ -243,10 +243,10 @@ steps:
       interval_bed: haplotypecaller_autosome_PAR_interval_bed
       interval_list: haplotypecaller_autosome_PAR_interval_list
       gatk4_HaplotypeCaller_java_options: gatk4_HaplotypeCaller_java_options
-      gatk4_HaplotypeCaller_num_threads: coresMin
+      gatk4_HaplotypeCaller_num_threads: cores
       ploidy:
         valueFrom: $(1)
-      bgzip_num_threads: coresMin
+      bgzip_num_threads: cores
     out:
       - vcf_gz
       - wgs_metrics
@@ -267,10 +267,10 @@ steps:
       interval_bed: haplotypecaller_chrX_nonPAR_interval_bed
       interval_list: haplotypecaller_chrX_nonPAR_interval_list
       gatk4_HaplotypeCaller_java_options: gatk4_HaplotypeCaller_java_options
-      gatk4_HaplotypeCaller_num_threads: coresMin
+      gatk4_HaplotypeCaller_num_threads: cores
       ploidy:
         valueFrom: $(2) 
-      bgzip_num_threads: coresMin
+      bgzip_num_threads: cores
     out:
       - vcf_gz
       - wgs_metrics
@@ -291,10 +291,10 @@ steps:
       interval_bed: haplotypecaller_chrX_nonPAR_interval_bed
       interval_list: haplotypecaller_chrX_nonPAR_interval_list
       gatk4_HaplotypeCaller_java_options: gatk4_HaplotypeCaller_java_options
-      gatk4_HaplotypeCaller_num_threads: coresMin
+      gatk4_HaplotypeCaller_num_threads: cores
       ploidy:
         valueFrom: $(1) 
-      bgzip_num_threads: coresMin
+      bgzip_num_threads: cores
     out:
       - vcf_gz
       - wgs_metrics
@@ -315,10 +315,10 @@ steps:
       interval_bed: haplotypecaller_chrY_nonPAR_interval_bed
       interval_list: haplotypecaller_chrY_nonPAR_interval_list
       gatk4_HaplotypeCaller_java_options: gatk4_HaplotypeCaller_java_options
-      gatk4_HaplotypeCaller_num_threads: coresMin
+      gatk4_HaplotypeCaller_num_threads: cores
       ploidy:
         valueFrom: $(1) 
-      bgzip_num_threads: coresMin
+      bgzip_num_threads: cores
     out:
       - vcf_gz
       - wgs_metrics

--- a/per-sample/Workflows/per-sample.cwl
+++ b/per-sample/Workflows/per-sample.cwl
@@ -18,7 +18,7 @@ requirements:
     outdirMin: 40960
     ramMin: 48000
     tmpdirMin: 65536
-    coresMin: 16
+    coresMin: $(inputs.coresMin)
 
 inputs:
   reference:
@@ -34,10 +34,9 @@ inputs:
       - .alt
       - .fai
       - ^.dict
-  bwa_num_threads:
+  coresMin:
     type: int
-    doc: number of cpu cores to be used
-    default: 1
+    doc: coresMin
   bwa_bases_per_batch:
     type: int
     doc: bases in each batch
@@ -122,17 +121,8 @@ inputs:
       items: int
     default: [10, 20, 30]
     doc: Use static quantized quality scores to a given number of levels (with -bqsr)
-  samtools_num_threads:
-    type: int
-    default: 1
   gatk4_HaplotypeCaller_java_options:
     type: string?
-  gatk4_HaplotypeCaller_num_threads:
-    type: int
-    default: 1
-  bgzip_num_threads:
-    type: int
-    default: 1
   # haplotypecaller interval=autosome-PAR, ploidy=2
   haplotypecaller_autosome_PAR_interval_bed:
     type: File
@@ -158,7 +148,7 @@ steps:
     run: ../Tools/fastqPE2bam.cwl
     in:
       reference: reference
-      bwa_num_threads: bwa_num_threads
+      bwa_num_threads: coresMin
       bwa_bases_per_batch: bwa_bases_per_batch
       sortsam_java_options: sortsam_java_options
       sortsam_max_records_in_ram: sortsam_max_records_in_ram
@@ -188,7 +178,7 @@ steps:
     run: ../Tools/fastqSE2bam.cwl
     in:
       reference: reference
-      bwa_num_threads: bwa_num_threads
+      bwa_num_threads: coresMin
       bwa_bases_per_batch: bwa_bases_per_batch
       sortsam_java_options: sortsam_java_options
       sortsam_max_records_in_ram: sortsam_max_records_in_ram
@@ -229,7 +219,7 @@ steps:
       gatk4_BaseRecalibrator_java_options: gatk4_BaseRecalibrator_java_options
       gatk4_ApplyBQSR_java_options: gatk4_ApplyBQSR_java_options
       static_quantized_quals: static_quantized_quals
-      samtools_num_threads: samtools_num_threads
+      samtools_num_threads: coresMin
     out:
       - markdup_metrics
       - markdup_log
@@ -253,10 +243,10 @@ steps:
       interval_bed: haplotypecaller_autosome_PAR_interval_bed
       interval_list: haplotypecaller_autosome_PAR_interval_list
       gatk4_HaplotypeCaller_java_options: gatk4_HaplotypeCaller_java_options
-      gatk4_HaplotypeCaller_num_threads: gatk4_HaplotypeCaller_num_threads
+      gatk4_HaplotypeCaller_num_threads: coresMin
       ploidy:
         valueFrom: $(1)
-      bgzip_num_threads: bgzip_num_threads
+      bgzip_num_threads: coresMin
     out:
       - vcf_gz
       - wgs_metrics
@@ -277,10 +267,10 @@ steps:
       interval_bed: haplotypecaller_chrX_nonPAR_interval_bed
       interval_list: haplotypecaller_chrX_nonPAR_interval_list
       gatk4_HaplotypeCaller_java_options: gatk4_HaplotypeCaller_java_options
-      gatk4_HaplotypeCaller_num_threads: gatk4_HaplotypeCaller_num_threads
+      gatk4_HaplotypeCaller_num_threads: coresMin
       ploidy:
         valueFrom: $(2) 
-      bgzip_num_threads: bgzip_num_threads
+      bgzip_num_threads: coresMin
     out:
       - vcf_gz
       - wgs_metrics
@@ -301,10 +291,10 @@ steps:
       interval_bed: haplotypecaller_chrX_nonPAR_interval_bed
       interval_list: haplotypecaller_chrX_nonPAR_interval_list
       gatk4_HaplotypeCaller_java_options: gatk4_HaplotypeCaller_java_options
-      gatk4_HaplotypeCaller_num_threads: gatk4_HaplotypeCaller_num_threads
+      gatk4_HaplotypeCaller_num_threads: coresMin
       ploidy:
         valueFrom: $(1) 
-      bgzip_num_threads: bgzip_num_threads
+      bgzip_num_threads: coresMin
     out:
       - vcf_gz
       - wgs_metrics
@@ -325,10 +315,10 @@ steps:
       interval_bed: haplotypecaller_chrY_nonPAR_interval_bed
       interval_list: haplotypecaller_chrY_nonPAR_interval_list
       gatk4_HaplotypeCaller_java_options: gatk4_HaplotypeCaller_java_options
-      gatk4_HaplotypeCaller_num_threads: gatk4_HaplotypeCaller_num_threads
+      gatk4_HaplotypeCaller_num_threads: coresMin
       ploidy:
         valueFrom: $(1) 
-      bgzip_num_threads: bgzip_num_threads
+      bgzip_num_threads: coresMin
     out:
       - vcf_gz
       - wgs_metrics


### PR DESCRIPTION
Currently cwltool can not handle correctly input parameters in top level workflow .
So set constant value.

Set number of threads to sub workflow and tool, cwltool can handle these value correctly.